### PR TITLE
Case-insensitive wildcard returns

### DIFF
--- a/AIMLInterpreter.js
+++ b/AIMLInterpreter.js
@@ -58,7 +58,6 @@ var AIMLInterpreter = function(botAttributesParam){
     this.findAnswerInLoadedAIMLFiles = function(clientInput, cb){
         //check if all AIML files have been loaded. If not, call this method again after a delay
         if(isAIMLFileLoaded){
-            clientInput = clientInput.toUpperCase();
             wildCardArray = [];
             var result = '';
             for(var i = 0; i < domArray.length; i++){
@@ -425,7 +424,7 @@ var checkIfMessageMatchesPattern = function(userInput, patternText){
 
     //match userInput with the regex pattern
     //if it matches, matchedString is defined
-    var matchedString = userInput.match(regexPattern);
+    var matchedString = userInput.toUpperCase().match(regexPattern);
 
     if(matchedString){
         //the matched pattern must be at least as long as the user input or must contain the regex
@@ -476,7 +475,7 @@ var getWildCardValue = function(userInput, patternText){
     if(replaceArray.length > 1){
         //replace the string of the userInput which is fixed by the pattern
         for(var i = 0; i < replaceArray.length; i++){
-            wildCardInput = wildCardInput.replace(replaceArray[i], '|');
+            wildCardInput = wildCardInput.replace(new RegExp(replaceArray[i], 'i'), '|');
         }
         //split the wildCardInput string by | to differentiate multiple * inputs
         //e.g. userInput = WHAT IS THE RELATION BETWEEN TIM AND STRUPPI?

--- a/test.js
+++ b/test.js
@@ -7,6 +7,15 @@ var callback = function(answer, wildCardArray, input){
     console.log(answer + ' | ' + wildCardArray + ' | ' + input);
 };
 
+var caseCallback = function(answer, wildCardArray, input){
+  if (answer == this) {
+    console.log(answer + ' | ' + wildCardArray + ' | ' + input);
+  } else {
+    console.log('ERROR:', answer);
+    console.log('   Expected:', this.toString());
+  }
+};
+
 
 // Test bot attributes
 aimlInterpreter.findAnswerInLoadedAIMLFiles('What is your name?', callback);
@@ -67,3 +76,9 @@ aimlInterpreter.findAnswerInLoadedAIMLFiles('Test condition and srai', callback)
 
 // Test finding nothing
 aimlInterpreter.findAnswerInLoadedAIMLFiles('Test the wildcard pattern!', callback);
+
+// Case insensitive testing
+aimlInterpreter.findAnswerInLoadedAIMLFiles('You feel BAD', caseCallback.bind('I feel BAD!'));
+aimlInterpreter.findAnswerInLoadedAIMLFiles('You feel good', caseCallback.bind('I feel good!'));
+aimlInterpreter.findAnswerInLoadedAIMLFiles('You feel hAPPy', caseCallback.bind('I feel HAPPy!')); // INTENTIONAL ERROR CHECKING
+aimlInterpreter.findAnswerInLoadedAIMLFiles('You feel FINEeeeee', caseCallback.bind('I feel FINEEEEEE!')); // INTENTIONAL ERROR CHECKING


### PR DESCRIPTION
The current version should not be altering the casing of the `clientInput` when doing wildcard matching.

E.g. user says `My name is Ben`, the wildcard should be `Ben`, not `BEN`.

This pull request updates use of casing to return casing as inputted by user. If developer wants input to be all uppercase, they can `.toUpperCase()` their input before calling `findAnswerInLoadedAIMLFiles()`.